### PR TITLE
Rename project to MulDoc

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,5 +1,5 @@
-(package "mldoc" "0.3.0" "Multi ElDoc integration")
+(package "muldoc" "0.4.0" "Multi ElDoc integration")
 (source melpa)
 (source gnu)
 
-(package-file "mldoc.el")
+(package-file "muldoc.el")

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EMACS ?= emacs
-ELS = mldoc.el
-AUTOLOADS = mldoc-autoloads.el
+ELS = muldoc.el
+AUTOLOADS = muldoc-autoloads.el
 ELCS = $(ELS:.el=.elc)
 
 %.elc: %.el
@@ -14,10 +14,10 @@ $(AUTOLOADS): $(ELS)
 	$(EMACS) -Q -batch -L . --eval \
 	"(progn \
 	   (require 'package) \
-	   (package-generate-autoloads \"mldoc\" default-directory))"
+	   (package-generate-autoloads \"muldoc\" default-directory))"
 
 clean:
 	rm -f $(ELCS) $(AUTOLOADS)
 
 test: clean all
-	$(EMACS) -Q -batch -L . -l tests/mldoc-test.el -f ert-run-tests-batch-and-exit
+	$(EMACS) -Q -batch -L . -l tests/muldoc-test.el -f ert-run-tests-batch-and-exit

--- a/README.org
+++ b/README.org
@@ -1,40 +1,40 @@
-* MLDoc - Multi ElDoc integration
-*MLDoc* extends ElDoc and makes function definition very easy.
+* MulDoc - Multi ElDoc integration
+*MulDoc* extends ElDoc and makes function definition very easy.
 ** What is ElDoc?
 [[https://www.emacswiki.org/emacs/ElDoc][ElDoc]] is a minor mode to show documentation in echo area.
 ElDoc function is implemented for several languages besides Emacs Lisp.
-** Why MLDoc?
-MLDoc solves ElDoc problem.
+** Why MulDoc?
+MulDoc solves ElDoc problem.
 - ElDoc can usually only register one or two functions.
 - ElDoc implementations are difficult to understand and tends to be untestable.
-MLDoc has APIs for end users and Lisp package developers.
+MulDoc has APIs for end users and Lisp package developers.
 ** API for users
-*Note*: no end-user MLDoc implementation yet.
+*Note*: no end-user MulDoc implementation yet.
 #+BEGIN_SRC emacs-lisp
 (defun my-foo-mode-setup ()
   "Setup function for `foo-mode'."
-  (mldoc-mode 1)
-  (push mldoc-documentation-functions #'mldoc-foo)
-  (push mldoc-documentation-functions #'mldoc-html))
+  (muldoc-mode 1)
+  (push muldoc-documentation-functions #'muldoc-foo)
+  (push muldoc-documentation-functions #'muldoc-html))
 
 (with-eval-after-load "foo-mode"
   (add-hook 'foo-mode-hook 'my-foo-mode-setup))
 #+END_SRC
 ** API for developers
-*** MLDoc DSL
+*** MulDoc DSL
 **** Example
 #+BEGIN_SRC emacs-lisp
-(defcustom foo-mldoc-function-form
+(defcustom foo-muldoc-function-form
   '(return-type " " function "(" (params ", " :type " " :name) ")")
-  "MLDoc display format for Foo function call."
-  :group 'mldoc-foo
+  "MulDoc display format for Foo function call."
+  :group 'muldoc-foo
   :type 'sexp)
 
-(define-mldoc foo-mldoc-func
-  "MLDoc function for Foo language."
+(define-muldoc foo-muldoc-func
+  "MulDoc function for Foo language."
   ;; This function is extremely simplified, but represents the specification of
   ;; the value that an actual implementation should return.
-  (mldoc-list foo-mldoc-function-form
+  (muldoc-list foo-muldoc-function-form
               :params '((:type "string" :name "message"))
               :current-param 0
               :values (list :function "print")))
@@ -56,6 +56,6 @@ Actually the DSL is just a list.  Its structure is =(cons form plist)=.
 It is an [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Property-Lists.html#Property-Lists][Property List]] with the following keys.
 - =:params=: List of =string= or =plist=.
 - =:current-param=: 0-origin current position of argument list.
-*** macro =(define-mldoc name docstring &rest body)=
+*** macro =(define-muldoc name docstring &rest body)=
 This macro is very similar to defun.
-It's actually just a defun wrapper, but it is responsible for converting between MLDoc DSL and ElDoc output formats.
+It's actually just a defun wrapper, but it is responsible for converting between MulDoc DSL and ElDoc output formats.

--- a/tests/muldoc-test.el
+++ b/tests/muldoc-test.el
@@ -1,6 +1,6 @@
-;;; mldoc-test.el --- Tests for MLDoc                -*- lexical-binding: t; -*-
+;;; muldoc-test.el --- Tests for MulDoc              -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2019  Friends of Emacs-PHP development
+;; Copyright (C) 2023  Friends of Emacs-PHP development
 
 ;; Author: USAMI Kenta <tadsan@zonu.me>
 ;; Created: 25 Jul 2019
@@ -21,28 +21,28 @@
 
 ;;; Commentary:
 
-;; Tests for MLDoc.
+;; Tests for MulDoc.
 
 ;;; Code:
 (require 'ert)
-(require 'mldoc)
+(require 'muldoc)
 (require 'cl-lib)
 
-(ert-deftest mldoc-test--build-list ()
+(ert-deftest muldoc-test--build-list ()
   (let ((data
          `(("Empty spec and no keywords"
-            ,(mldoc--build-list '())
+            ,(muldoc--build-list '())
             ,(list))
            ("Spec has a string"
-            ,(mldoc--build-list '(""))
+            ,(muldoc--build-list '(""))
             ,(list ""))
            ("Spec has function value"
-            ,(mldoc--build-list '(:foo ": " :function)
+            ,(muldoc--build-list '(:foo ": " :function)
                            :values (list :function "f" :foo "hoge"))
             ,(list "hoge" ": "
                    (propertize "f" 'face font-lock-function-name-face)))
            ("Spec has arg list"
-            ,(mldoc--build-list '(:function "(" (params ", ") ")")
+            ,(muldoc--build-list '(:function "(" (params ", ") ")")
                            :values (list :function "f")
                            :params '("a" "b" "c")
                            :current-param 2)
@@ -54,57 +54,57 @@
     (cl-loop for (desc actual expected) in data
              do (should (equal (cons desc expected) (cons desc actual))))))
 
-(ert-deftest mldoc-test--propertize-param ()
+(ert-deftest muldoc-test--propertize-param ()
   (let ((data
-         ;; (mldoc--propertize-arg arg is-current-param arg-spec)
+         ;; (muldoc--propertize-arg arg is-current-param arg-spec)
          `(("Simple argument"
-            ,(mldoc--propertize-param '(:name "a") nil '(:name))
+            ,(muldoc--propertize-param '(:name "a") nil '(:name))
             "a")
            ("Simple argument and current argument"
-            ,(mldoc--propertize-param '(:name "a") t '(:name))
+            ,(muldoc--propertize-param '(:name "a") t '(:name))
             ,(propertize "a" 'face '(:weight bold)))
            ("Argument has :name and :type"
-            ,(mldoc--propertize-param '(:name "a" :type "string")
+            ,(muldoc--propertize-param '(:name "a" :type "string")
                                nil
                                '(:name " / " :type))
             ,(concat "a / " (propertize "string" 'face font-lock-function-name-face))))))
     (cl-loop for (desc actual expected) in data
              do (should (equal (cons desc expected) (cons desc actual))))))
 
-(ert-deftest mldoc-test--evalute-spec ()
+(ert-deftest muldoc-test--evalute-spec ()
   (let ((data
          `(("if-spec passed `T' as cond, returns 1."
-            ,(mldoc--evalute-spec '(if (eq 1 1) 1 2) nil nil)
+            ,(muldoc--evalute-spec '(if (eq 1 1) 1 2) nil nil)
             1)
            ("if-spec passed `NIL' as cond, returns 2."
-            ,(mldoc--evalute-spec '(if (eq 1 2) 1 2) nil nil)
+            ,(muldoc--evalute-spec '(if (eq 1 2) 1 2) nil nil)
             2)
            ("if-spec passed `NIL' as cond and multiple else clause, returns 3."
-            ,(mldoc--evalute-spec '(if (eq 1 2) 1 2 3) nil nil)
+            ,(muldoc--evalute-spec '(if (eq 1 2) 1 2 3) nil nil)
             3)
            ("when-spec passed `T', return 1."
-            ,(mldoc--evalute-spec '(when (eq 1 1) 1) nil nil)
+            ,(muldoc--evalute-spec '(when (eq 1 1) 1) nil nil)
             1)
            ("when-spec passed `NIL', return NIL."
-            ,(mldoc--evalute-spec '(when (eq 1 2) 1) nil nil)
+            ,(muldoc--evalute-spec '(when (eq 1 2) 1) nil nil)
             nil)
            ("unless-spec passed `T', return `NIL'."
-            ,(mldoc--evalute-spec '(unless (eq 1 1) 1) nil nil)
+            ,(muldoc--evalute-spec '(unless (eq 1 1) 1) nil nil)
             nil)
            ("unless-spec passed `NIL', return 1."
-            ,(mldoc--evalute-spec '(unless (eq 1 2) 1) nil nil)
+            ,(muldoc--evalute-spec '(unless (eq 1 2) 1) nil nil)
             1)
            ("eval-spec passed `1', return 1."
-            ,(mldoc--evalute-spec '(eval 1) nil nil)
+            ,(muldoc--evalute-spec '(eval 1) nil nil)
             1)
            ("eval-spec passed `emacs-version', return value of emacs-version."
-            ,(mldoc--evalute-spec '(eval emacs-version) nil nil)
+            ,(muldoc--evalute-spec '(eval emacs-version) nil nil)
             ,emacs-version)
            ("function-spec passed `(symbol-value emacs-version)', return value of emacs-version."
-            ,(mldoc--evalute-spec '(symbol-value 'emacs-version) nil nil)
+            ,(muldoc--evalute-spec '(symbol-value 'emacs-version) nil nil)
             ,emacs-version))))
     (cl-loop for (desc actual expected) in data
              do (should (equal (cons desc expected) (cons desc actual))))))
 
-(provide 'mldoc-test)
-;;; mldoc-test.el ends here
+(provide 'muldoc-test)
+;;; muldoc-test.el ends here

--- a/tests/sample-muldoc.el
+++ b/tests/sample-muldoc.el
@@ -1,6 +1,6 @@
-;;; sample-mldoc.el --- Example implementation of MLDoc  -*- lexical-binding: t; -*-
+;;; sample-muldoc.el --- Example implementation of MulDoc -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021  Friends of Emacs-PHP development
+;; Copyright (C) 2023  Friends of Emacs-PHP development
 
 ;; Author: USAMI Kenta <tadsan@zonu.me>
 ;; Created: 25 Jul 2019
@@ -22,7 +22,7 @@
 
 ;;; Commentary:
 
-;; This file is sample implementation for MLDoc.
+;; This file is sample implementation for MulDoc.
 ;; "Samp" is a tiny programming language that similar to C.
 ;;
 ;;     foo(1, 2, 3);
@@ -31,7 +31,7 @@
 ;;
 
 ;;; Code:
-(require 'mldoc)
+(require 'muldoc)
 (require 'cc-langs)
 
 ;; Samp Language definitions:
@@ -70,39 +70,39 @@
                return i
                finally return i))))
 
-;; MLDoc implementations:
-(defcustom samp-mldoc-func-form
+;; MulDoc implementations:
+(defcustom samp-muldoc-func-form
   '(:function "(" (params ", " :type " " :name) ")")
-  "MLDoc display form for Samp function call."
-  :group 'samp-mldoc
+  "MulDoc display form for Samp function call."
+  :group 'samp-muldoc
   :type 'sexp)
 
-(defcustom samp-mldoc-const-form
+(defcustom samp-muldoc-const-form
   '(:constant ": " :desc)
-  "MLDoc display form for Samp constant."
-  :group 'samp-mldoc
+  "MulDoc display form for Samp constant."
+  :group 'samp-muldoc
   :type 'sexp)
 
-(define-mldoc samp-mldoc-func
-  "MLDoc function for Foo language."
+(define-muldoc samp-muldoc-func
+  "MulDoc function for Foo language."
   ;; This function is extremely simplified, but represents the specification of
   ;; the value that an actual implementation should return.
   (when-let (spec (samp-current-arg-info))
     (let ((name (car spec))
           (params (mapcar (lambda (s) (cons :name s)) (cdr spec))))
-      (mldoc-list samp-mldoc-func-form
+      (muldoc-list samp-muldoc-func-form
                   :params params
                   :current-param (samp-current-arg-pos)
                   :values (list :function name)))))
 
-(define-mldoc samp-mldoc-const
-  "MLDoc function for Foo language."
+(define-muldoc samp-muldoc-const
+  "MulDoc function for Foo language."
   ;; This function is extremely simplified, but represents the specification of
   ;; the value that an actual implementation should return.
   (when-let (const (assoc (thing-at-point 'symbol t) samp-defined-constants))
     (let ((name (car const))
           (desc (cadr const)))
-      (mldoc-list samp-mldoc-const-form
+      (muldoc-list samp-muldoc-const-form
                   :values (list :constant name :desc desc)))))
 
 ;; Major mode for *.samp
@@ -125,15 +125,15 @@
 ;; User function (~/.emacs.d/init.el):
 (defun user-setup-samp-mode ()
   "User defined function for hook."
-  (mldoc-mode +1)
-  (add-to-list 'mldoc-documentation-functions #'samp-mldoc-func)
-  (add-to-list 'mldoc-documentation-functions #'samp-mldoc-const))
+  (muldoc-mode +1)
+  (add-to-list 'muldoc-documentation-functions #'samp-muldoc-func)
+  (add-to-list 'muldoc-documentation-functions #'samp-muldoc-const))
 
-(with-eval-after-load "sample-mldoc"
+(with-eval-after-load "sample-muldoc"
   (add-hook 'samp-mode-hook #'user-setup-samp-mode))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.samp\\'" . samp-mode) t)
 
-(provide 'sample-mldoc)
-;;; sample-mldoc.el ends here
+(provide 'sample-muldoc)
+;;; sample-muldoc.el ends here


### PR DESCRIPTION
"ML" has tended to refer to "machine learning" more than ever before, and it feels like a non-unique name, so we're renaming it.